### PR TITLE
docs: 顶部推荐区替换为用例合集链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,11 @@ Feishu × AI Assistant **standalone bridge** — no public server required
 
 ---
 
-> ### 🚀 新项目：[OpenCrew](https://github.com/AlexAnys/opencrew) — 把你的 OpenClaw 变成一支 AI 团队
+> ### 📚 装好了飞书桥接，然后做什么？
 >
-> 一个 Agent 承担所有事情时，上下文会膨胀、经验会丢失、你会变成瓶颈。
+> 查看 **[OpenClaw 中文用例 & 案例合集](https://github.com/AlexAnys/awesome-openclaw-usecases-zh)** — 46 个经过验证的真实场景，涵盖自动化办公、内容创作、运维、AI 助理、知识管理，新手友好。
 >
-> **OpenCrew 的解法**：多个 Agent 各管各的领域，Slack 频道=岗位，经验自动沉淀，可逆操作无需你确认。
->
-> 3 个 Agent 起步 · 10 分钟部署 · 不用写代码 · 不影响你现有的 OpenClaw
->
-> **[查看 GitHub →](https://github.com/AlexAnys/opencrew)**
+> 飞书 × OpenClaw 的专属用例也在里面 🦞
 
 ---
 


### PR DESCRIPTION
## 改动

将 README 顶部推荐区从 OpenCrew 项目介绍替换为 [awesome-openclaw-usecases-zh](https://github.com/AlexAnys/awesome-openclaw-usecases-zh) 链接。

### 改前
> 🚀 新项目：OpenCrew — 把你的 OpenClaw 变成一支 AI 团队
> （5 行 OpenCrew 介绍）

### 改后
> 📚 装好了飞书桥接，然后做什么？
> 查看 OpenClaw 中文用例 & 案例合集 — 46 个真实场景...
> 飞书 × OpenClaw 的专属用例也在里面 🦞

## 为什么

用户装完飞书桥接后，下一步最自然的需求是「这东西能做什么」。指向 46 个真实用例比指向另一个框架项目更贴合用户意图，同时为用例仓库增加一个来自 325⭐ 仓库的内链（SEO 信号）。